### PR TITLE
Enhanced game context with team logos, player headshots, and live auto-sync

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "a.espncdn.com",
+        pathname: "/i/teamlogos/**",
+      },
+      {
+        protocol: "https",
+        hostname: "a.espncdn.com",
+        pathname: "/i/headshots/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: Request) {
         ownerId: string;
         ownerName: string;
         rosterSlot: string;
+        position: string;
         team: string | null;
       }
     >();
@@ -47,6 +48,7 @@ export async function GET(request: Request) {
         ownerId: roster.owner.id,
         ownerName: roster.owner.name,
         rosterSlot: roster.rosterSlot,
+        position: roster.player.position,
         team: roster.player.team,
       });
     }
@@ -90,6 +92,7 @@ export async function GET(request: Request) {
         shortName:
           event.shortName ||
           `${awayCompetitor.team.abbreviation} @ ${homeCompetitor.team.abbreviation}`,
+        date: event.date,
         status: {
           state: event.status.type.state as "pre" | "in" | "post",
           completed: event.status.type.completed,
@@ -132,7 +135,7 @@ export async function GET(request: Request) {
               gameInfo.players.push({
                 playerId: rosterInfo.playerId,
                 playerName: player.name,
-                position: player.position || "FLEX",
+                position: rosterInfo.position,
                 team: player.team || "",
                 ownerId: rosterInfo.ownerId,
                 ownerName: rosterInfo.ownerName,

--- a/src/components/games-today.tsx
+++ b/src/components/games-today.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { CURRENT_SEASON_YEAR } from "@/lib/constants";
+import { TeamLogo } from "./team-logo";
+
+interface GameInfo {
+  eventId: string;
+  week: number;
+  name: string;
+  shortName: string;
+  date: string;
+  status: {
+    state: "pre" | "in" | "post";
+    completed: boolean;
+    description: string;
+    detail: string;
+    displayClock?: string;
+    period?: number;
+  };
+  homeTeam: {
+    abbreviation: string;
+    displayName: string;
+    score: number;
+  };
+  awayTeam: {
+    abbreviation: string;
+    displayName: string;
+    score: number;
+  };
+  hasRosteredPlayers?: boolean;
+}
+
+interface GamesTodayProps {
+  rosteredTeams?: Set<string>;
+  onRefresh?: () => void;
+  onLiveGamesChange?: (hasLive: boolean) => void;
+}
+
+const WEEK_LABELS: Record<number, string> = {
+  1: "Wild Card",
+  2: "Divisional",
+  3: "Conference",
+  5: "Super Bowl",
+};
+
+function formatQuarter(period?: number): string {
+  if (!period) return "";
+  if (period <= 4) return `Q${period}`;
+  return `OT${period - 4 > 1 ? period - 4 : ""}`;
+}
+
+function formatGameTime(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function GameCard({ game, rosteredTeams }: { game: GameInfo; rosteredTeams?: Set<string> }) {
+  const isLive = game.status.state === "in";
+  const isFinal = game.status.completed;
+  const isScheduled = game.status.state === "pre";
+
+  const awayWinning = game.awayTeam.score > game.homeTeam.score;
+  const homeWinning = game.homeTeam.score > game.awayTeam.score;
+
+  const hasAway = rosteredTeams?.has(game.awayTeam.abbreviation.toUpperCase());
+  const hasHome = rosteredTeams?.has(game.homeTeam.abbreviation.toUpperCase());
+  const hasPlayers = hasAway || hasHome;
+
+  return (
+    <Link
+      href={`/game/${game.eventId}`}
+      className={`flex-shrink-0 w-[200px] p-3 rounded-lg transition-all hover:scale-[1.02] ${
+        isLive
+          ? "bg-green-900/20 border border-green-500/40 hover:border-green-500/60"
+          : hasPlayers
+            ? "bg-[var(--chalk-blue)]/10 border border-[var(--chalk-blue)]/30 hover:border-[var(--chalk-blue)]/50"
+            : "bg-[rgba(0,0,0,0.3)] border border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)]"
+      }`}
+    >
+      {/* Header: Week + Status */}
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] text-[var(--chalk-muted)] uppercase tracking-wide">
+          {WEEK_LABELS[game.week] || `Week ${game.week}`}
+        </span>
+        {isLive && (
+          <span className="flex items-center gap-1 text-[10px] text-green-400 font-medium">
+            <span className="w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse"></span>
+            {formatQuarter(game.status.period)} {game.status.displayClock}
+          </span>
+        )}
+        {isFinal && (
+          <span className="text-[10px] text-[var(--chalk-muted)] font-medium">FINAL</span>
+        )}
+        {isScheduled && (
+          <span className="text-[10px] text-[var(--chalk-blue)]">{formatGameTime(game.date)}</span>
+        )}
+      </div>
+
+      {/* Away Team */}
+      <div className="flex items-center justify-between py-1">
+        <div className="flex items-center gap-2">
+          <TeamLogo abbreviation={game.awayTeam.abbreviation} size="sm" />
+          <span
+            className={`text-sm font-bold ${
+              isFinal && awayWinning ? "text-[var(--chalk-green)]" : "text-[var(--chalk-white)]"
+            }`}
+          >
+            {game.awayTeam.abbreviation}
+          </span>
+          {hasAway && (
+            <span
+              className="w-1.5 h-1.5 bg-[var(--chalk-blue)] rounded-full"
+              title="Rostered players on this team"
+            ></span>
+          )}
+        </div>
+        <span
+          className={`text-sm font-bold ${
+            !isScheduled
+              ? awayWinning
+                ? "text-[var(--chalk-green)]"
+                : "text-[var(--chalk-white)]"
+              : "text-[var(--chalk-muted)]"
+          }`}
+        >
+          {!isScheduled ? game.awayTeam.score : "-"}
+        </span>
+      </div>
+
+      {/* Home Team */}
+      <div className="flex items-center justify-between py-1">
+        <div className="flex items-center gap-2">
+          <TeamLogo abbreviation={game.homeTeam.abbreviation} size="sm" />
+          <span
+            className={`text-sm font-bold ${
+              isFinal && homeWinning ? "text-[var(--chalk-green)]" : "text-[var(--chalk-white)]"
+            }`}
+          >
+            {game.homeTeam.abbreviation}
+          </span>
+          {hasHome && (
+            <span
+              className="w-1.5 h-1.5 bg-[var(--chalk-blue)] rounded-full"
+              title="Rostered players on this team"
+            ></span>
+          )}
+        </div>
+        <span
+          className={`text-sm font-bold ${
+            !isScheduled
+              ? homeWinning
+                ? "text-[var(--chalk-green)]"
+                : "text-[var(--chalk-white)]"
+              : "text-[var(--chalk-muted)]"
+          }`}
+        >
+          {!isScheduled ? game.homeTeam.score : "-"}
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+export function GamesToday({ rosteredTeams, onRefresh, onLiveGamesChange }: GamesTodayProps) {
+  const [games, setGames] = useState<GameInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showMyGamesOnly, setShowMyGamesOnly] = useState(false);
+
+  const fetchGames = useCallback(async () => {
+    try {
+      setLoading(true);
+      const weeks = [1, 2, 3, 5];
+      const allGames: GameInfo[] = [];
+
+      for (const week of weeks) {
+        const response = await fetch(`/api/games?year=${CURRENT_SEASON_YEAR}&week=${week}`);
+        if (!response.ok) continue;
+        const result = await response.json();
+
+        const gamesWithWeek = result.games.map((g: GameInfo) => ({
+          ...g,
+          week,
+        }));
+        allGames.push(...gamesWithWeek);
+      }
+
+      // Sort games: Live first, then upcoming (by date), then completed
+      allGames.sort((a, b) => {
+        // Live games first
+        if (a.status.state === "in" && b.status.state !== "in") return -1;
+        if (a.status.state !== "in" && b.status.state === "in") return 1;
+
+        // Then upcoming games by date
+        if (a.status.state === "pre" && b.status.state === "pre") {
+          return new Date(a.date).getTime() - new Date(b.date).getTime();
+        }
+        if (a.status.state === "pre" && b.status.state !== "pre") return -1;
+        if (a.status.state !== "pre" && b.status.state === "pre") return 1;
+
+        // Completed games last, newest first
+        return new Date(b.date).getTime() - new Date(a.date).getTime();
+      });
+
+      setGames(allGames);
+    } catch (err) {
+      console.error("Failed to fetch games:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGames();
+  }, [fetchGames]);
+
+  // Report live games status to parent
+  useEffect(() => {
+    const hasLive = games.some((g) => g.status.state === "in");
+    onLiveGamesChange?.(hasLive);
+  }, [games, onLiveGamesChange]);
+
+  // Auto-refresh game status every 60 seconds if there are live games
+  // Note: This only refreshes game cards, the parent handles ESPN sync
+  useEffect(() => {
+    const hasLiveGames = games.some((g) => g.status.state === "in");
+    if (!hasLiveGames) return;
+
+    const interval = setInterval(() => {
+      fetchGames();
+    }, 60000);
+
+    return () => clearInterval(interval);
+  }, [games, fetchGames]);
+
+  // Filter games if showing only my games
+  const filteredGames =
+    showMyGamesOnly && rosteredTeams
+      ? games.filter(
+          (g) =>
+            rosteredTeams.has(g.awayTeam.abbreviation.toUpperCase()) ||
+            rosteredTeams.has(g.homeTeam.abbreviation.toUpperCase())
+        )
+      : games;
+
+  // Get counts for display
+  const liveCount = games.filter((g) => g.status.state === "in").length;
+  const upcomingCount = games.filter((g) => g.status.state === "pre").length;
+
+  if (loading && games.length === 0) {
+    return (
+      <div className="chalk-box p-4">
+        <div className="text-center text-[var(--chalk-muted)] text-sm">Loading games...</div>
+      </div>
+    );
+  }
+
+  if (games.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="chalk-box p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-bold text-[var(--chalk-white)]">Playoff Games</h2>
+          {liveCount > 0 && (
+            <span className="flex items-center gap-1 text-xs text-green-400">
+              <span className="w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse"></span>
+              {liveCount} Live
+            </span>
+          )}
+          {upcomingCount > 0 && (
+            <span className="text-xs text-[var(--chalk-muted)]">{upcomingCount} Upcoming</span>
+          )}
+        </div>
+        {rosteredTeams && rosteredTeams.size > 0 && (
+          <button
+            onClick={() => setShowMyGamesOnly(!showMyGamesOnly)}
+            className={`text-xs px-2 py-1 rounded transition-colors ${
+              showMyGamesOnly
+                ? "bg-[var(--chalk-blue)] text-white"
+                : "bg-[rgba(255,255,255,0.1)] text-[var(--chalk-muted)] hover:text-[var(--chalk-white)]"
+            }`}
+          >
+            Rostered Only
+          </button>
+        )}
+      </div>
+
+      {/* Scrollable Game Cards */}
+      <div className="flex gap-3 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-thin scrollbar-thumb-[rgba(255,255,255,0.2)] scrollbar-track-transparent">
+        {filteredGames.map((game) => (
+          <GameCard key={game.eventId} game={game} rosteredTeams={rosteredTeams} />
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-3 pt-3 border-t border-dashed border-[var(--chalk-muted)]/30 text-[10px] text-[var(--chalk-muted)]">
+        <span className="flex items-center gap-1">
+          <span className="w-1.5 h-1.5 bg-[var(--chalk-blue)] rounded-full"></span>
+          Rostered players
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-1.5 h-1.5 bg-green-400 rounded-full"></span>
+          Live game
+        </span>
+        <Link href="/schedule" className="ml-auto text-[var(--chalk-blue)] hover:underline">
+          View full schedule
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring-breakdown.tsx
+++ b/src/components/scoring-breakdown.tsx
@@ -5,9 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 
 interface StatLine {
   label: string;
-  value: string; // Formatted value with units (e.g., "361 yds", "2 TDs")
+  value: string;
   points: number;
-  // Extended calculation details for tooltip
   rawValue: number;
   multiplier: number;
   operation: "multiply" | "divide";
@@ -19,25 +18,19 @@ interface ScoringBreakdownProps {
   week: number;
   weekLabel: string;
   stats: {
-    // Passing
     passYards?: number;
     passTd?: number;
     passInt?: number;
-    // Rushing
     rushYards?: number;
     rushTd?: number;
-    // Receiving
     recYards?: number;
     recTd?: number;
     receptions?: number;
-    // Kicking
     fgPoints?: number;
     xpMade?: number;
     xpMissed?: number;
-    // Misc
     twoPtConv?: number;
     fumblesLost?: number;
-    // Defense
     sacks?: number;
     interceptions?: number;
     fumblesRecovered?: number;
@@ -48,27 +41,20 @@ interface ScoringBreakdownProps {
   totalPoints: number;
 }
 
-// Scoring rules for display - Half PPR league
 const RULES = {
-  // Passing
   passYardsPerPoint: 30,
   passTd: 6,
   passInt: -2,
-  // Rushing
   rushYardsPerPoint: 10,
   rushTd: 6,
-  // Receiving (Half PPR)
   recYardsPerPoint: 10,
   recTd: 6,
   ppr: 0.5,
-  // Misc Offense
   twoPtConv: 2,
   fumbleLost: -2,
   returnTd: 6,
-  // Kicking
   xpMade: 1,
   xpMiss: -1,
-  // Defense
   sack: 1,
   defInt: 2,
   fumRec: 2,
@@ -83,126 +69,92 @@ function formatPoints(pts: number): string {
   return `${sign}${pts.toFixed(1)}`;
 }
 
-// Tooltip component for calculation details
-function CalculationTooltip({ line, children }: { line: StatLine; children: React.ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsOpen(!isOpen);
-  };
-
-  const handleClose = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsOpen(false);
-  };
-
+// Expandable stat row for mobile-friendly interaction
+function StatRow({
+  line,
+  isExpanded,
+  onToggle,
+}: {
+  line: StatLine;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
   return (
-    <div className="relative inline-block w-full">
-      <div
-        onMouseEnter={() => setIsOpen(true)}
-        onMouseLeave={() => setIsOpen(false)}
-        onClick={handleClick}
-        className="cursor-help"
+    <div className="border-b border-dashed border-[rgba(255,255,255,0.1)] last:border-0">
+      {/* Main row - always visible */}
+      <button
+        onClick={onToggle}
+        className="w-full py-2 flex items-center justify-between hover:bg-[rgba(255,255,255,0.05)] transition-colors text-left"
       >
-        {children}
-      </div>
+        <span className="flex items-center gap-1.5 text-[var(--chalk-white)]">
+          {line.label}
+          <svg
+            className={`w-3.5 h-3.5 text-[var(--chalk-blue)] transition-transform ${isExpanded ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-[var(--chalk-muted)] text-sm">{line.value}</span>
+          <span
+            className={`font-semibold min-w-[50px] text-right ${
+              line.points > 0
+                ? "text-[var(--chalk-green)]"
+                : line.points < 0
+                  ? "text-red-400"
+                  : "text-[var(--chalk-muted)]"
+            }`}
+          >
+            {formatPoints(line.points)}
+          </span>
+        </div>
+      </button>
 
-      {isOpen && (
-        <>
-          {/* Mobile backdrop for easy dismissal */}
-          <div className="md:hidden fixed inset-0 z-40" onClick={handleClose} />
-          <div className="absolute z-50 left-0 right-0 md:left-auto md:right-auto md:w-80 mt-1 p-4 bg-[#1a1a2e] border border-[var(--chalk-blue)] rounded-lg shadow-xl text-sm animate-in fade-in duration-150">
-            <div className="space-y-3">
-              {/* Header with close button on mobile */}
-              <div className="flex justify-between items-center border-b border-[rgba(255,255,255,0.1)] pb-2">
-                <span className="font-bold text-[var(--chalk-yellow)]">{line.label}</span>
-                <div className="flex items-center gap-2">
+      {/* Expanded details */}
+      {isExpanded && (
+        <div className="pb-3 px-2 animate-in slide-in-from-top-2 duration-200">
+          <div className="bg-[rgba(0,0,0,0.3)] rounded-lg p-3 space-y-3">
+            {/* Calculation */}
+            <div className="flex items-center justify-center gap-2 font-mono text-sm">
+              {line.operation === "divide" ? (
+                <>
+                  <span className="text-[var(--chalk-white)]">{line.rawValue}</span>
+                  <span className="text-[var(--chalk-muted)]">÷</span>
+                  <span className="text-[var(--chalk-white)]">{line.multiplier}</span>
+                  <span className="text-[var(--chalk-muted)]">=</span>
                   <span className="text-[var(--chalk-green)] font-bold">
-                    {formatPoints(line.points)} pts
+                    {line.points.toFixed(1)}
                   </span>
-                  {/* Close button - always visible but especially important on touch */}
-                  <button
-                    onClick={handleClose}
-                    className="ml-2 p-1 rounded-full hover:bg-[rgba(255,255,255,0.1)] transition-colors min-w-[28px] min-h-[28px] flex items-center justify-center"
-                    aria-label="Close"
+                </>
+              ) : (
+                <>
+                  <span className="text-[var(--chalk-white)]">{line.rawValue}</span>
+                  <span className="text-[var(--chalk-muted)]">×</span>
+                  <span className="text-[var(--chalk-white)]">{line.multiplier}</span>
+                  <span className="text-[var(--chalk-muted)]">=</span>
+                  <span
+                    className={`font-bold ${line.points >= 0 ? "text-[var(--chalk-green)]" : "text-red-400"}`}
                   >
-                    <svg
-                      className="w-4 h-4 text-[var(--chalk-muted)]"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-
-              {/* Calculation breakdown */}
-              <div className="space-y-2">
-                <div className="text-[var(--chalk-muted)] text-xs uppercase tracking-wide">
-                  Calculation
-                </div>
-
-                <div className="bg-[rgba(0,0,0,0.3)] rounded p-3 font-mono text-center">
-                  {line.operation === "divide" ? (
-                    <div className="space-y-1">
-                      <div className="text-[var(--chalk-white)] text-lg">{line.rawValue}</div>
-                      <div className="border-t border-[var(--chalk-muted)] w-16 mx-auto"></div>
-                      <div className="text-[var(--chalk-muted)]">{line.multiplier}</div>
-                      <div className="text-[var(--chalk-blue)] mt-2">
-                        = {(line.rawValue / line.multiplier).toFixed(2)}
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="space-y-1">
-                      <div className="flex items-center justify-center gap-2">
-                        <span className="text-[var(--chalk-white)] text-lg">{line.rawValue}</span>
-                        <span className="text-[var(--chalk-muted)]">×</span>
-                        <span className="text-[var(--chalk-white)] text-lg">{line.multiplier}</span>
-                      </div>
-                      <div className="text-[var(--chalk-blue)] mt-2">
-                        = {(line.rawValue * line.multiplier).toFixed(1)}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Explanation */}
-              <div className="space-y-1">
-                <div className="text-[var(--chalk-muted)] text-xs uppercase tracking-wide">
-                  Scoring Rule
-                </div>
-                <p className="text-[var(--chalk-white)] text-xs leading-relaxed">
-                  {line.explanation}
-                </p>
-              </div>
-
-              {/* Formula summary */}
-              <div className="bg-[rgba(255,255,255,0.05)] rounded p-2 text-xs text-center text-[var(--chalk-muted)]">
-                {line.operation === "divide"
-                  ? `${line.rawValue} ÷ ${line.multiplier} = ${line.points.toFixed(1)} pts`
-                  : `${line.rawValue} × ${line.multiplier} = ${line.points.toFixed(1)} pts`}
-              </div>
+                    {line.points.toFixed(1)}
+                  </span>
+                </>
+              )}
             </div>
 
-            {/* Arrow pointer - hidden on mobile for cleaner look */}
-            <div className="hidden md:block absolute -top-2 left-4 w-3 h-3 bg-[#1a1a2e] border-l border-t border-[var(--chalk-blue)] transform rotate-45"></div>
+            {/* Explanation */}
+            <p className="text-xs text-[var(--chalk-muted)] leading-relaxed">{line.explanation}</p>
           </div>
-        </>
+        </div>
       )}
     </div>
   );
 }
 
 export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreakdownProps) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const statLines: StatLine[] = [];
 
   // Passing
@@ -215,7 +167,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.passYards,
       multiplier: RULES.passYardsPerPoint,
       operation: "divide",
-      explanation: `Every ${RULES.passYardsPerPoint} passing yards equals 1 fantasy point. This rewards quarterbacks for moving the ball through the air, though at a lower rate than rushing/receiving yards since passing is more common.`,
+      explanation: `Every ${RULES.passYardsPerPoint} passing yards = 1 point`,
     });
   }
   if (stats.passTd && stats.passTd > 0) {
@@ -227,19 +179,19 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.passTd,
       multiplier: RULES.passTd,
       operation: "multiply",
-      explanation: `Each passing touchdown is worth ${RULES.passTd} points. Throwing a TD pass is one of the most valuable plays a quarterback can make.`,
+      explanation: `Each passing touchdown = ${RULES.passTd} points`,
     });
   }
   if (stats.passInt && stats.passInt > 0) {
     const pts = stats.passInt * RULES.passInt;
     statLines.push({
-      label: "Interceptions Thrown",
+      label: "Interceptions",
       value: stats.passInt === 1 ? "1 INT" : `${stats.passInt} INTs`,
       points: pts,
       rawValue: stats.passInt,
       multiplier: RULES.passInt,
       operation: "multiply",
-      explanation: `Each interception thrown costs ${Math.abs(RULES.passInt)} points. Turnovers are costly mistakes that can change games, so they result in negative fantasy points.`,
+      explanation: `Each interception thrown = ${RULES.passInt} points`,
     });
   }
 
@@ -253,7 +205,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.rushYards,
       multiplier: RULES.rushYardsPerPoint,
       operation: "divide",
-      explanation: `Every ${RULES.rushYardsPerPoint} rushing yards equals 1 fantasy point. Rushing yards are valued higher than passing yards because they're harder to gain.`,
+      explanation: `Every ${RULES.rushYardsPerPoint} rushing yards = 1 point`,
     });
   }
   if (stats.rushTd && stats.rushTd > 0) {
@@ -265,7 +217,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.rushTd,
       multiplier: RULES.rushTd,
       operation: "multiply",
-      explanation: `Each rushing touchdown is worth ${RULES.rushTd} points. Punching the ball into the end zone on the ground is a high-value play.`,
+      explanation: `Each rushing touchdown = ${RULES.rushTd} points`,
     });
   }
 
@@ -279,7 +231,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.receptions,
       multiplier: RULES.ppr,
       operation: "multiply",
-      explanation: `This is a Half-PPR (Point Per Reception) league. Each catch is worth ${RULES.ppr} points, rewarding receivers for their involvement in the offense beyond just yards gained.`,
+      explanation: `Half-PPR: Each catch = ${RULES.ppr} points`,
     });
   }
   if (stats.recYards && stats.recYards > 0) {
@@ -291,7 +243,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.recYards,
       multiplier: RULES.recYardsPerPoint,
       operation: "divide",
-      explanation: `Every ${RULES.recYardsPerPoint} receiving yards equals 1 fantasy point. Like rushing, receiving yards are valued at a premium rate.`,
+      explanation: `Every ${RULES.recYardsPerPoint} receiving yards = 1 point`,
     });
   }
   if (stats.recTd && stats.recTd > 0) {
@@ -303,7 +255,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.recTd,
       multiplier: RULES.recTd,
       operation: "multiply",
-      explanation: `Each receiving touchdown is worth ${RULES.recTd} points. Catching a TD in the end zone is one of the most exciting plays in football.`,
+      explanation: `Each receiving touchdown = ${RULES.recTd} points`,
     });
   }
 
@@ -316,45 +268,45 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.fgPoints,
       multiplier: 1,
       operation: "multiply",
-      explanation: `Field goals are scored based on distance: 0-39 yards = 3 pts, 40-49 yards = 4 pts, 50+ yards = 5 pts. Only missed FGs under 40 yards cost 1 point (no penalty for missing 40+ yard attempts). Longer kicks are rewarded more because they're harder to make.`,
+      explanation: `FG scoring by distance: 0-39 yds = 3 pts, 40-49 yds = 4 pts, 50+ yds = 5 pts`,
     });
   }
   if (stats.xpMade && stats.xpMade > 0) {
     const pts = stats.xpMade * RULES.xpMade;
     statLines.push({
-      label: "Extra Points Made",
+      label: "Extra Points",
       value: stats.xpMade === 1 ? "1 XP" : `${stats.xpMade} XPs`,
       points: pts,
       rawValue: stats.xpMade,
       multiplier: RULES.xpMade,
       operation: "multiply",
-      explanation: `Each successful extra point kick is worth ${RULES.xpMade} point. These are typically high-percentage kicks from 33 yards out.`,
+      explanation: `Each extra point made = ${RULES.xpMade} point`,
     });
   }
   if (stats.xpMissed && stats.xpMissed > 0) {
     const pts = stats.xpMissed * RULES.xpMiss;
     statLines.push({
-      label: "Extra Points Missed",
+      label: "XP Missed",
       value: stats.xpMissed === 1 ? "1 miss" : `${stats.xpMissed} misses`,
       points: pts,
       rawValue: stats.xpMissed,
       multiplier: RULES.xpMiss,
       operation: "multiply",
-      explanation: `Each missed extra point costs ${Math.abs(RULES.xpMiss)} point. Missing a routine kick is penalized in fantasy scoring.`,
+      explanation: `Each extra point missed = ${RULES.xpMiss} point`,
     });
   }
 
-  // Miscellaneous
+  // Misc
   if (stats.twoPtConv && stats.twoPtConv > 0) {
     const pts = stats.twoPtConv * RULES.twoPtConv;
     statLines.push({
-      label: "2-Point Conversions",
+      label: "2-PT Conversions",
       value: stats.twoPtConv === 1 ? "1 conv" : `${stats.twoPtConv} conv`,
       points: pts,
       rawValue: stats.twoPtConv,
       multiplier: RULES.twoPtConv,
       operation: "multiply",
-      explanation: `Each successful 2-point conversion is worth ${RULES.twoPtConv} points. Both the passer and receiver get credit for a successful 2-point play.`,
+      explanation: `Each 2-point conversion = ${RULES.twoPtConv} points`,
     });
   }
   if (stats.fumblesLost && stats.fumblesLost > 0) {
@@ -366,7 +318,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.fumblesLost,
       multiplier: RULES.fumbleLost,
       operation: "multiply",
-      explanation: `Each fumble lost costs ${Math.abs(RULES.fumbleLost)} points. Turnovers are costly mistakes that hurt both real and fantasy teams.`,
+      explanation: `Each fumble lost = ${RULES.fumbleLost} points`,
     });
   }
 
@@ -380,7 +332,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.sacks,
       multiplier: RULES.sack,
       operation: "multiply",
-      explanation: `Each sack recorded by the defense is worth ${RULES.sack} point. Sacks disrupt the opponent's offense and often result in lost yardage.`,
+      explanation: `Each sack = ${RULES.sack} point`,
     });
   }
   if (stats.interceptions && stats.interceptions > 0) {
@@ -392,7 +344,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.interceptions,
       multiplier: RULES.defInt,
       operation: "multiply",
-      explanation: `Each interception by the defense is worth ${RULES.defInt} points. Turnovers are game-changing plays that reward the defense.`,
+      explanation: `Each interception = ${RULES.defInt} points`,
     });
   }
   if (stats.fumblesRecovered && stats.fumblesRecovered > 0) {
@@ -404,7 +356,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.fumblesRecovered,
       multiplier: RULES.fumRec,
       operation: "multiply",
-      explanation: `Each fumble recovered by the defense is worth ${RULES.fumRec} points. Creating and recovering turnovers is a key defensive skill.`,
+      explanation: `Each fumble recovered = ${RULES.fumRec} points`,
     });
   }
   if (stats.defensiveTd && stats.defensiveTd > 0) {
@@ -416,7 +368,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.defensiveTd,
       multiplier: RULES.dstTd,
       operation: "multiply",
-      explanation: `Each defensive or special teams touchdown is worth ${RULES.dstTd} points. Pick-sixes, fumble returns, punt/kick returns for TDs all count.`,
+      explanation: `Each defensive/ST touchdown = ${RULES.dstTd} points`,
     });
   }
   if (stats.safeties && stats.safeties > 0) {
@@ -428,7 +380,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
       rawValue: stats.safeties,
       multiplier: RULES.safety,
       operation: "multiply",
-      explanation: `Each safety is worth ${RULES.safety} points. Safeties are rare plays where the defense tackles the ball carrier in their own end zone.`,
+      explanation: `Each safety = ${RULES.safety} points`,
     });
   }
   if (stats.pointsAllowed !== undefined) {
@@ -436,26 +388,25 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
     let explanation = "";
     if (stats.pointsAllowed === 0) {
       pts = 10;
-      explanation = "A shutout! Holding the opponent scoreless earns the maximum 10 points.";
+      explanation = "Shutout = 10 points";
     } else if (stats.pointsAllowed <= 6) {
       pts = 7;
-      explanation =
-        "Allowing only 1-6 points is an excellent defensive performance worth 7 points.";
+      explanation = "1-6 points allowed = 7 points";
     } else if (stats.pointsAllowed <= 13) {
       pts = 4;
-      explanation = "Allowing 7-13 points is a solid defensive game worth 4 points.";
+      explanation = "7-13 points allowed = 4 points";
     } else if (stats.pointsAllowed <= 20) {
       pts = 1;
-      explanation = "Allowing 14-20 points is an average defensive performance worth 1 point.";
+      explanation = "14-20 points allowed = 1 point";
     } else if (stats.pointsAllowed <= 27) {
       pts = 0;
-      explanation = "Allowing 21-27 points is below average and earns 0 points.";
+      explanation = "21-27 points allowed = 0 points";
     } else if (stats.pointsAllowed <= 34) {
       pts = -1;
-      explanation = "Allowing 28-34 points is a poor defensive showing that costs 1 point.";
+      explanation = "28-34 points allowed = -1 point";
     } else {
       pts = -3;
-      explanation = "Allowing 35+ points is a bad defensive game that costs 3 points.";
+      explanation = "35+ points allowed = -3 points";
     }
 
     statLines.push({
@@ -475,7 +426,7 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
         <CardHeader className="pb-2">
           <CardTitle className="text-base flex justify-between">
             <span className="text-[var(--chalk-white)]">{weekLabel}</span>
-            <span className="text-[var(--chalk-muted)]">0.0 pts</span>
+            <span className="text-[var(--chalk-muted)]">-</span>
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -488,73 +439,37 @@ export function ScoringBreakdown({ weekLabel, stats, totalPoints }: ScoringBreak
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base flex justify-between">
+        <CardTitle className="text-base flex justify-between items-center">
           <span className="text-[var(--chalk-white)]">{weekLabel}</span>
           <span className="text-[var(--chalk-green)] font-bold chalk-score">
             {totalPoints.toFixed(1)} pts
           </span>
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-dashed border-[rgba(255,255,255,0.2)]">
-              <th className="py-1 text-left font-medium text-[var(--chalk-muted)]">Stat</th>
-              <th className="py-1 text-right font-medium text-[var(--chalk-muted)]">Value</th>
-              <th className="py-1 text-right font-medium text-[var(--chalk-muted)]">Points</th>
-            </tr>
-          </thead>
-          <tbody>
-            {statLines.map((line, i) => (
-              <CalculationTooltip key={i} line={line}>
-                <tr className="border-b border-dashed border-[rgba(255,255,255,0.1)] last:border-0 hover:bg-[rgba(255,255,255,0.05)] transition-colors">
-                  <td className="py-2 text-[var(--chalk-white)]">
-                    <span className="flex items-center gap-1">
-                      {line.label}
-                      <svg
-                        className="w-3 h-3 text-[var(--chalk-blue)] opacity-60"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                    </span>
-                  </td>
-                  <td className="py-2 text-right font-mono text-[var(--chalk-muted)]">
-                    {line.value}
-                  </td>
-                  <td
-                    className={`py-2 text-right font-semibold chalk-score ${
-                      line.points > 0
-                        ? "text-[var(--chalk-green)]"
-                        : line.points < 0
-                          ? "text-[var(--chalk-red)]"
-                          : "text-[var(--chalk-muted)]"
-                    }`}
-                  >
-                    {formatPoints(line.points)}
-                  </td>
-                </tr>
-              </CalculationTooltip>
-            ))}
-          </tbody>
-          <tfoot>
-            <tr className="border-t-2 border-dashed border-[rgba(255,255,255,0.3)]">
-              <td colSpan={2} className="py-2 font-semibold text-[var(--chalk-white)]">
-                Total
-              </td>
-              <td className="py-2 text-right font-bold text-[var(--chalk-green)] chalk-score">
-                {totalPoints.toFixed(1)}
-              </td>
-            </tr>
-          </tfoot>
-        </table>
+      <CardContent className="pt-0">
+        {/* Hint for mobile */}
+        <p className="text-[10px] text-[var(--chalk-muted)] mb-2">
+          Tap any stat for scoring details
+        </p>
+
+        <div className="text-sm">
+          {statLines.map((line, i) => (
+            <StatRow
+              key={i}
+              line={line}
+              isExpanded={expandedIndex === i}
+              onToggle={() => setExpandedIndex(expandedIndex === i ? null : i)}
+            />
+          ))}
+
+          {/* Total */}
+          <div className="flex justify-between items-center pt-2 border-t-2 border-dashed border-[rgba(255,255,255,0.3)] mt-1">
+            <span className="font-semibold text-[var(--chalk-white)]">Total</span>
+            <span className="font-bold text-[var(--chalk-green)] chalk-score">
+              {totalPoints.toFixed(1)}
+            </span>
+          </div>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/team-logo.tsx
+++ b/src/components/team-logo.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+interface TeamLogoProps {
+  abbreviation: string;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
+  className?: string;
+}
+
+const SIZE_MAP = {
+  xs: 16,
+  sm: 24,
+  md: 32,
+  lg: 48,
+  xl: 64,
+};
+
+/**
+ * Team logo component that fetches from ESPN's CDN
+ * Falls back to showing the team abbreviation if the image fails to load
+ */
+export function TeamLogo({ abbreviation, size = "md", className = "" }: TeamLogoProps) {
+  const [hasError, setHasError] = useState(false);
+  const pixelSize = SIZE_MAP[size];
+
+  // ESPN uses lowercase abbreviations for logo URLs
+  const logoUrl = `https://a.espncdn.com/i/teamlogos/nfl/500/${abbreviation.toLowerCase()}.png`;
+
+  if (hasError) {
+    // Fallback to abbreviation text
+    return (
+      <div
+        className={`flex items-center justify-center bg-[rgba(255,255,255,0.1)] rounded-full font-bold text-[var(--chalk-muted)] ${className}`}
+        style={{ width: pixelSize, height: pixelSize, fontSize: pixelSize * 0.35 }}
+      >
+        {abbreviation}
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={logoUrl}
+      alt={`${abbreviation} logo`}
+      width={pixelSize}
+      height={pixelSize}
+      className={`object-contain ${className}`}
+      onError={() => setHasError(true)}
+      unoptimized // ESPN CDN images don't need Next.js optimization
+    />
+  );
+}
+
+/**
+ * Team logo with name displayed next to it
+ */
+export function TeamLogoWithName({
+  abbreviation,
+  displayName,
+  size = "md",
+  className = "",
+  nameClassName = "",
+}: TeamLogoProps & { displayName: string; nameClassName?: string }) {
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <TeamLogo abbreviation={abbreviation} size={size} />
+      <span className={nameClassName}>{displayName}</span>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -221,6 +221,7 @@ export interface PlayoffGame {
   week: number;
   name: string;
   shortName: string;
+  date: string;
   status: GameStatus;
   homeTeam: GameTeam;
   awayTeam: GameTeam;


### PR DESCRIPTION
## Summary
- Add team logos throughout the app (schedule, game pages, player pages) using ESPN CDN
- Add GamesToday component showing current/upcoming playoff games with live status indicators
- Add player headshots and aggregated playoff stats on player detail pages
- Add pre-game player preview on game pages showing rostered players with their stats
- Refactor scoring breakdown from hover tooltips to accordion-style expandable rows for better mobile UX
- Implement auto-sync with ESPN during live games (every 60 seconds)
- Clarify UI around sync vs cache refresh behavior
- Fix player position showing as FLEX instead of actual position

## Test plan
- [ ] Verify team logos display correctly on schedule page
- [ ] Verify game cards show live/upcoming status correctly
- [ ] Verify player headshots load on player detail pages
- [ ] Verify scoring breakdown accordion works on mobile
- [ ] Verify pre-game view shows rostered players
- [ ] Verify auto-sync indicator shows correctly during live games
- [ ] Verify "Cache refresh" shows when no live games

🤖 Generated with [Claude Code](https://claude.com/claude-code)